### PR TITLE
[1.19 Fabric] Check the Item instead of ItemStack

### DIFF
--- a/src/main/java/dev/sapphic/armorsoundtweak/ArmorSoundTweak.java
+++ b/src/main/java/dev/sapphic/armorsoundtweak/ArmorSoundTweak.java
@@ -186,7 +186,7 @@ public final class ArmorSoundTweak implements ClientModInitializer {
             final var newItem = newEquipment.next();
             final var oldItem = oldEquipment.next();
 
-            if (!ItemStack.matches(newItem, oldItem)) {
+            if (!newItem.is(oldItem.getItem())) {
               final @Nullable SoundEvent sound = getEquipSound(newItem, oldItem);
 
               if (sound != null) {


### PR DESCRIPTION
Fixes #7 by checking the ItemStack Item type instead of the ItemStack itself. The sound will play if the new equipment item is a different item type than the old one.

Caveat to this approach: when replacing an equipment item with one of the same type (eg. replace an unenchanted iron helmet with an enchanted one), the sound will not play.